### PR TITLE
Restore proper copyrights

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2016 Anton Smirnov
 Copyright (c) 2017 Mathias San Miguel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/commonmarker-pygments.gemspec
+++ b/commonmarker-pygments.gemspec
@@ -6,7 +6,7 @@ require 'commonmarker/pygments/version'
 Gem::Specification.new do |spec|
   spec.name          = "commonmarker-pygments"
   spec.version       = Commonmarker::Pygments::VERSION
-  spec.authors       = ["Mathias San Miguel"]
+  spec.authors       = ["Mathias San Miguel", "Anton Smirnov"]
   spec.email         = ["mathiassanmiguel@gmail.com"]
 
   spec.summary       = "A CommonMarker wrapper with syntax highlight support by Pygments."


### PR DESCRIPTION
MIT clearly says: "The above copyright notice and this permission notice shall be included in all copies or *substantial portions* of the Software."

Plz restore my copyrights and authorship in your gem